### PR TITLE
check the value of `ring` in advance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 [[package]]
 name = "cdshealpix"
 version = "0.7.3"
-source = "git+https://github.com/keewis/cds-healpix-rust.git?branch=kth-ring-neighbours#25ebac0af481b3aafe7f4cde65b0a2ea4c6a5299"
+source = "git+https://github.com/keewis/cds-healpix-rust.git?branch=kth-ring-neighbours#f3d79af5a160d81bccc6d94b30d2eded0e74fb7a"
 dependencies = [
  "base64",
  "bincode",
@@ -201,7 +201,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "healpix-geo"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "cdshealpix",
  "ndarray",

--- a/python/healpix_geo/nested.py
+++ b/python/healpix_geo/nested.py
@@ -1,20 +1,7 @@
 import numpy as np
 
 from healpix_geo import healpix_geo
-
-
-def _check_depth(depth):
-    ravel_depth = np.ravel(np.atleast_1d(depth))
-    if any(ravel_depth < 0) or any(ravel_depth > 29):
-        raise ValueError("Depth must be in the [0, 29] closed range")
-
-
-def _check_ipixels(data, depth):
-    npix = 12 * 4 ** (depth)
-    if (data >= npix).any() or (data < 0).any():
-        raise ValueError(
-            f"The input HEALPix cells contains value out of [0, {npix - 1}]"
-        )
+from healpix_geo.utils import _check_depth, _check_ipixels
 
 
 def neighbours_disk(ipix, depth, ring, num_threads=0):

--- a/python/healpix_geo/nested.py
+++ b/python/healpix_geo/nested.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from healpix_geo import healpix_geo
-from healpix_geo.utils import _check_depth, _check_ipixels
+from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
 
 
 def neighbours_disk(ipix, depth, ring, num_threads=0):
@@ -50,6 +50,7 @@ def neighbours_disk(ipix, depth, ring, num_threads=0):
     ipix = np.atleast_1d(ipix)
     _check_ipixels(data=ipix, depth=depth)
     ipix = ipix.astype(np.uint64)
+    _check_ring(depth, ring)
 
     # Allocation of the array containing the neighbours
     neighbours = np.full(

--- a/python/healpix_geo/utils.py
+++ b/python/healpix_geo/utils.py
@@ -13,3 +13,13 @@ def _check_ipixels(data, depth):
         raise ValueError(
             f"The input HEALPix cells contains value out of [0, {npix - 1}]"
         )
+
+
+def _check_ring(depth, ring):
+    nside = 2**depth
+
+    if ring > nside:
+        raise ValueError(
+            "Crossing base cell boundaries more than once is not supported."
+            f" Received ring={ring}, but expected an integer in the range of [0, {nside}]."
+        )

--- a/python/healpix_geo/utils.py
+++ b/python/healpix_geo/utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def _check_depth(depth):
+    ravel_depth = np.ravel(np.atleast_1d(depth))
+    if any(ravel_depth < 0) or any(ravel_depth > 29):
+        raise ValueError("Depth must be in the [0, 29] closed range")
+
+
+def _check_ipixels(data, depth):
+    npix = 12 * 4**depth
+    if (data >= npix).any() or (data < 0).any():
+        raise ValueError(
+            f"The input HEALPix cells contains value out of [0, {npix - 1}]"
+        )


### PR DESCRIPTION
As of the most recent commit, the implementation in `cds-healpix-rust` panics on `k > nside`. However, `PanicError` is not a very informative exception, so we need to raise a custom exception before calling the rust code.