### PR TITLE
emulate `neighbours_disk` for the `"ring"` scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "healpix-geo"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "cdshealpix",
  "ndarray",

--- a/python/healpix_geo/__init__.py
+++ b/python/healpix_geo/__init__.py
@@ -1,3 +1,3 @@
-from healpix_geo import nested
+from healpix_geo import nested, ring
 
-__all__ = ["nested"]
+__all__ = ["nested", "ring"]

--- a/python/healpix_geo/ring.py
+++ b/python/healpix_geo/ring.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+from healpix_geo import healpix_geo
+from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
+
+
+def neighbours_disk(ipix, depth, ring, num_threads=0):
+    """Get the kth ring neighbouring cells of some HEALPix cells at a given depth.
+
+    This method returns a :math:`N` x :math:`(2 k + 1)^2` `np.uint64` numpy array containing the neighbours of each cell of the :math:`N` sized `ipix` array.
+    This method is wrapped around the `neighbours_in_kth_ring <https://docs.rs/cdshealpix/0.1.5/cdshealpix/nested/struct.Layer.html#method.neighbours_in_kth_ring>`__
+    method from the `cdshealpix Rust crate <https://crates.io/crates/cdshealpix>`__.
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes given as a `np.uint64` numpy array.
+    depth : int
+        The depth of the HEALPix cells.
+    ring : int
+        The number of rings. `ring=0` returns just the input cell ids, `ring=1` returns the 8 (or 7) immediate
+        neighbours, `ring=2` returns the 8 (or 7) immediate neighbours plus their immediate neighbours (a total of 24 cells), and so on.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    neighbours : `numpy.ndarray`
+        A :math:`N` x :math:`(2 k + 1)^2` `np.int64` numpy array containing the kth ring neighbours of each cell.
+        The :math:`5^{th}` element corresponds to the index of HEALPix cell from which the neighbours are evaluated.
+        All its 8 neighbours occup the remaining elements of the line.
+
+    Raises
+    ------
+    ValueError
+        When the HEALPix cell indexes given have values out of :math:`[0, 4^{29 - depth}[`.
+
+    Examples
+    --------
+    >>> from cdshealpix import neighbours_in_kth_ring
+    >>> import numpy as np
+    >>> ipix = np.array([42, 6, 10])
+    >>> depth = 12
+    >>> ring = 3
+    >>> neighbours = neighbours_in_kth_ring(ipix, depth, ring)
+    """
+    _check_depth(depth)
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+    _check_ring(depth, ring)
+
+    # Allocation of the array containing the neighbours
+    neighbours = np.full(
+        (*ipix.shape, (2 * ring + 1) ** 2), dtype=np.int64, fill_value=-1
+    )
+    num_threads = np.uint16(num_threads)
+    healpix_geo.ring.neighbours_disk(depth, ipix, ring, neighbours, num_threads)
+
+    return neighbours

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,73 @@ mod nested {
 }
 
 #[pymodule]
+mod ring {
+    use super::*;
+    use cdshealpix as healpix;
+    use ndarray::{s, Array1, Zip};
+    use numpy::{PyArrayDyn, PyArrayMethods};
+
+    /// Wrapper of `neighbours_disk`
+    /// The given array must be of size (2 * ring + 1)^2
+    #[pyfunction]
+    unsafe fn neighbours_disk<'a>(
+        _py: Python,
+        depth: u8,
+        ipix: &Bound<'a, PyArrayDyn<u64>>,
+        ring: u32,
+        neighbours: &Bound<'a, PyArrayDyn<i64>>,
+        nthreads: u16,
+    ) -> PyResult<()> {
+        let ipix = ipix.as_array();
+        let mut neighbours = neighbours.as_array_mut();
+        let layer = healpix::nested::get(depth);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(nthreads as usize)
+                .build()
+                .unwrap();
+            pool.install(|| {
+                Zip::from(neighbours.rows_mut())
+                    .and(&ipix)
+                    .par_for_each(|mut n, &p| {
+                        let p_nested = layer.from_ring(p);
+                        let map = Array1::from_iter(
+                            layer
+                                .neighbours_disk(p_nested, ring)
+                                .into_iter()
+                                .map(|v| layer.to_ring(v) as i64),
+                        );
+
+                        n.slice_mut(s![..map.len()]).assign(&map);
+                    })
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            Zip::from(neighbours.rows_mut())
+                .and(&ipix)
+                .for_each(|mut n, &p| {
+                    let p_nested = layer.from_ring(p);
+                    let map = Array1::from_iter(
+                        layer
+                            .neighbours_disk(p_nested, ring)
+                            .into_iter()
+                            .map(|v| layer.to_ring(v) as i64),
+                    );
+
+                    n.slice_mut(s![..]).assign(&map);
+                });
+        }
+        Ok(())
+    }
+}
+
+#[pymodule]
 mod healpix_geo {
     #[pymodule_export]
     use super::nested;
+
+    #[pymodule_export]
+    use super::ring;
 }


### PR DESCRIPTION
This emulates the `neighbours_disk` algorithm by translating cell ids to `"nested"`, performing the search, and then translating back.