### PR TITLE
avoid cache invalidation issues

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Create rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "py${{ matrix.python-version }}"
 
       - name: Help finding installed libraries
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -70,6 +70,8 @@ jobs:
             python=${{ matrix.python-version }}
       - name: Create rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "py${{ matrix.python-version }}"
       - name: Help finding installed libraries
         run: |
           pushd $CONDA_PREFIX


### PR DESCRIPTION
Choose a rust cache key that contains the python version