### PR TITLE
Make the ellipsoid constructable from the JS bindings

### DIFF
--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -15,6 +15,10 @@ wasm-bindgen = "0.2.123"
 healpix-geo-core = { workspace = true }
 cdshealpix = { workspace = true }
 geodesy = { workspace = true }
+# `geodesy` pulls in `uuid` (with `rng`/`v4`), which hard-errors on
+# `wasm32-unknown-unknown` unless a randomness backend is selected. These two
+# dependencies exist solely to enable that backend for the wasm build; neither
+# is used directly. Do not remove them.
 uuid = { version = "1.23.3", features = ["rng-getrandom"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 console_error_panic_hook = "0.1.7"

--- a/js/src/ellipsoid.rs
+++ b/js/src/ellipsoid.rs
@@ -18,14 +18,44 @@ pub struct EllipsoidInverse {
 }
 
 #[wasm_bindgen]
+impl EllipsoidInverse {
+    #[wasm_bindgen(constructor)]
+    pub fn new(semi_major_axis: f64, inverse_flattening: f64) -> Self {
+        Self {
+            semi_major_axis,
+            inverse_flattening,
+        }
+    }
+}
+
+#[wasm_bindgen]
 pub struct EllipsoidSemiMinor {
     pub semi_major_axis: f64,
     pub semi_minor_axis: f64,
 }
 
 #[wasm_bindgen]
+impl EllipsoidSemiMinor {
+    #[wasm_bindgen(constructor)]
+    pub fn new(semi_major_axis: f64, semi_minor_axis: f64) -> Self {
+        Self {
+            semi_major_axis,
+            semi_minor_axis,
+        }
+    }
+}
+
+#[wasm_bindgen]
 pub struct Sphere {
     pub radius: f64,
+}
+
+#[wasm_bindgen]
+impl Sphere {
+    #[wasm_bindgen(constructor)]
+    pub fn new(radius: f64) -> Self {
+        Self { radius }
+    }
 }
 
 impl Ellipsoid {

--- a/js/src/nested.rs
+++ b/js/src/nested.rs
@@ -7,6 +7,12 @@ use crate::coordinates::Coordinate;
 use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
+/// Nested index of the cell at the given z-order coordinates
+///
+/// Interleaves the bits of `i` and `j` — the two axes of the nested z-order
+/// numbering within a base-resolution pixel — into the cell index at `depth`.
+/// Note the parameter order: the function takes `(depth, j, i)` but interleaves
+/// them as `ij2h(i, j)`.
 #[wasm_bindgen(js_name = bitCombinedNested)]
 pub fn bit_combine(depth: u8, j: u32, i: u32) -> u64 {
     let zoc = healpix::nested::zordercurve::get_zoc(depth);
@@ -105,5 +111,33 @@ mod tests {
         let hash = bit_combine(depth, j, i);
 
         assert_eq!(hash, 2);
+    }
+
+    #[test]
+    fn test_healpix_to_lonlat_ellipsoid() {
+        use crate::ellipsoid::{EllipsoidInverse, Sphere};
+
+        let depth: u8 = 0;
+        // a base pixel whose center sits at a mid latitude (~41.8 deg), where the
+        // authalic -> geographic conversion produces a measurable difference
+        let ipix: u64 = 0;
+
+        let sphere_default = healpix_to_lonlat(ipix, depth, None);
+
+        // WGS84: the geographic latitude differs measurably from the authalic
+        // (spherical) latitude, while the longitude is unaffected
+        let wgs84 =
+            Ellipsoid::EllipsoidInverseFlattening(EllipsoidInverse::new(6378137.0, 298.257223563));
+        let ellipsoidal = healpix_to_lonlat(ipix, depth, Some(wgs84));
+
+        assert!((sphere_default.lon - ellipsoidal.lon).abs() < 1e-9);
+        assert!((sphere_default.lat - ellipsoidal.lat).abs() > 1e-3);
+
+        // an explicit sphere reproduces the default (radius does not affect lon/lat)
+        let sphere = Ellipsoid::Sphere(Sphere::new(6_371_000.0));
+        let explicit_sphere = healpix_to_lonlat(ipix, depth, Some(sphere));
+
+        assert!((sphere_default.lon - explicit_sphere.lon).abs() < 1e-9);
+        assert!((sphere_default.lat - explicit_sphere.lat).abs() < 1e-9);
     }
 }

--- a/js/src/ring.rs
+++ b/js/src/ring.rs
@@ -7,6 +7,12 @@ use crate::coordinates::Coordinate;
 use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
+/// Ring index of the cell at the given z-order coordinates
+///
+/// Interleaves the bits of `i` and `j` — the two axes of the nested z-order
+/// numbering within a base-resolution pixel — into the nested cell index at
+/// `depth`, then converts it to the ring scheme. Note the parameter order: the
+/// function takes `(depth, j, i)` but interleaves them as `ij2h(i, j)`.
 #[wasm_bindgen(js_name = bitCombinedRing)]
 pub fn bit_combine(depth: u8, j: u32, i: u32) -> u64 {
     let layer = healpix::nested::get(depth);

--- a/js/src/zuniq.rs
+++ b/js/src/zuniq.rs
@@ -7,6 +7,12 @@ use crate::coordinates::Coordinate;
 use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
+/// `zuniq` index of the cell at the given z-order coordinates
+///
+/// Interleaves the bits of `i` and `j` — the two axes of the nested z-order
+/// numbering within a base-resolution pixel — into the nested cell index at
+/// `depth`, then converts it to the `zuniq` scheme. Note the parameter order:
+/// the function takes `(depth, j, i)` but interleaves them as `ij2h(i, j)`.
 #[wasm_bindgen(js_name = bitCombinedZuniq)]
 pub fn bit_combine(depth: u8, j: u32, i: u32) -> u64 {
     let zoc = healpix::nested::zordercurve::get_zoc(depth);

--- a/rust/healpix-geo-core/src/ellipsoid.rs
+++ b/rust/healpix-geo-core/src/ellipsoid.rs
@@ -5,7 +5,6 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use serde::{de, ser};
 use std::collections::HashMap;
-use std::default::Default;
 use std::fmt;
 
 pub trait ReferenceBody {


### PR DESCRIPTION
 ## Changes

  - **Ellipsoid was unreachable from JS (blocker).** The generated `.d.ts` gave every
    `Ellipsoid` variant (`EllipsoidInverse` / `EllipsoidSemiMinor` / `Sphere`) a private
    constructor with no factory, yet `Ellipsoid` only ever appears as a function *input* —
    so callers could only pass `null` and always got the default sphere, making the
    ellipsoidal support unusable. Added `#[wasm_bindgen(constructor)]` to each variant; the
    `.d.ts` now exposes public constructors. Added a test that passes a WGS84 ellipsoid (and
    an explicit sphere) through `healpix_to_lonlat`.
  - Documented the `bitCombinedNested` / `bitCombinedRing` / `bitCombinedZuniq` functions,
    including that they take `(depth, j, i)` but interleave as `ij2h(i, j)`.
  - Added a comment in `js/Cargo.toml` explaining the `uuid` / `getrandom` dependencies —
    they look unused but are required to select uuid's randomness backend on `wasm32`
    (pulled in via `geodesy`); removing them breaks the wasm build.
  - Removed a redundant `use std::default::Default;` in core `ellipsoid.rs`.

  Verified: `wasm-pack build --target bundler` succeeds, crate tests pass (7), clippy clean.

  ## Follow-up suggestions (not addressed here and to be discussed)

  - **`spherical_vertex` + `ONE_OVER_NSIDE` in `js/src/geometry.rs`** is real projection
    logic living only in the binding. Per the "all logic in `healpix-geo-core`, bindings are
    thin wrappers" convention, it might be worth moving to core so a future Python
    single-vertex helper can share it. Not urgent.
  - **Export naming:** `bitCombinedNested/Ring/Zuniq` is past-tense and inconsistent with
    `healpixToLonLat*` / `vertex*`. Consider `bitCombineNested/Ring/Zuniq` before the npm
    package is published — and is "bit combine" the clearest name for "interleave i/j into a
    cell index"?
  - **`js/package.json` vs CI:** `wasm.yml` synthesizes `package.json` from `Cargo.toml` via
    `jq`, so the static `js/package.json` looks unused and the two `0.1.3` versions can
    drift. Might be worth picking one source of truth.

